### PR TITLE
Raise max number of open files for buildah

### DIFF
--- a/.github/workflows/spring-boot-pipeline.yaml
+++ b/.github/workflows/spring-boot-pipeline.yaml
@@ -92,9 +92,11 @@ jobs:
       with:
         containerfiles: deployment/docker/Dockerfile
         context: .
+        build-args: |
+          BASE_TAG=${{ steps.generate_tags.outputs.base_image_tag }}
         extra-args: |
           -v=/home/github/cache/maven:/m2/repository:shared,rw
-          --build-arg=BASE_TAG=${{ steps.generate_tags.outputs.base_image_tag }}
+          --ulimit=nofile=262144:262144
         tags: ${{ steps.generate_tags.outputs.tags }}
 
     - name: Push to ECR


### PR DESCRIPTION
Buildah had a way lower `nofile` limit than podman which broke some builds, so we need to raise it.

![screenshot-20220615-145702](https://user-images.githubusercontent.com/10406217/173834337-312739d6-f15d-483a-a46b-7b535ac14934.png)
![screenshot-20220615-145652](https://user-images.githubusercontent.com/10406217/173834345-221733b4-fd1d-45d4-b5a2-44531f56747d.png)
