### PR TITLE
Fix tag for master build

### DIFF
--- a/.github/workflows/spring-boot-pipeline.yaml
+++ b/.github/workflows/spring-boot-pipeline.yaml
@@ -77,7 +77,7 @@ jobs:
         if [ "${GITHUB_EVENT_NAME}" == "pull_request" ]; then
           echo "##[set-output name=tags;]074509403805.dkr.ecr.eu-west-1.amazonaws.com/${GITHUB_REPOSITORY:9}:${GITHUB_HEAD_REF}-gha 074509403805.dkr.ecr.eu-west-1.amazonaws.com/${GITHUB_REPOSITORY:9}:${GITHUB_SHA}-gha"
         else
-          echo "##[set-output name=tags;]074509403805.dkr.ecr.eu-west-1.amazonaws.com/${GITHUB_REPOSITORY:9}:${GITHUB_REF}-gha 074509403805.dkr.ecr.eu-west-1.amazonaws.com/${GITHUB_REPOSITORY:9}:${GITHUB_SHA}-gha"
+          echo "##[set-output name=tags;]074509403805.dkr.ecr.eu-west-1.amazonaws.com/${GITHUB_REPOSITORY:9}:${GITHUB_REF:11}-gha 074509403805.dkr.ecr.eu-west-1.amazonaws.com/${GITHUB_REPOSITORY:9}:${GITHUB_SHA}-gha"
         fi
 
         if [ "${{ inputs.base_image_branch }}" != "" ]; then


### PR DESCRIPTION
I wanted the tag to be dynamic instead of hardcoding it to master, unfortunately this resulted in `refs/heads/master`. This should fix it.