### PR TITLE
Fix commit SHA for pull requests

### DIFF
--- a/.github/workflows/spring-boot-pipeline.yaml
+++ b/.github/workflows/spring-boot-pipeline.yaml
@@ -75,7 +75,7 @@ jobs:
       shell: bash
       run: |
         if [ "${GITHUB_EVENT_NAME}" == "pull_request" ]; then
-          echo "##[set-output name=tags;]074509403805.dkr.ecr.eu-west-1.amazonaws.com/${GITHUB_REPOSITORY:9}:${GITHUB_HEAD_REF}-gha 074509403805.dkr.ecr.eu-west-1.amazonaws.com/${GITHUB_REPOSITORY:9}:${GITHUB_SHA}-gha"
+          echo "##[set-output name=tags;]074509403805.dkr.ecr.eu-west-1.amazonaws.com/${GITHUB_REPOSITORY:9}:${GITHUB_HEAD_REF}-gha 074509403805.dkr.ecr.eu-west-1.amazonaws.com/${GITHUB_REPOSITORY:9}:${{ github.event.pull_request.head.sha }}-gha"
         else
           echo "##[set-output name=tags;]074509403805.dkr.ecr.eu-west-1.amazonaws.com/${GITHUB_REPOSITORY:9}:${GITHUB_REF:11}-gha 074509403805.dkr.ecr.eu-west-1.amazonaws.com/${GITHUB_REPOSITORY:9}:${GITHUB_SHA}-gha"
         fi


### PR DESCRIPTION
This is driving me crazy... why is it so complicated to simply get the branch and commit ID?
For pull requests, ${GITHUB_SHA} is the ID of the last _merge_ commit.