### PR TITLE
Set auth file path for buildah

### DIFF
--- a/.github/workflows/spring-boot-pipeline.yaml
+++ b/.github/workflows/spring-boot-pipeline.yaml
@@ -89,6 +89,8 @@ jobs:
 
     - name: Build
       uses: redhat-actions/buildah-build@v2
+      env:
+        REGISTRY_AUTH_FILE: /run/user/1001/containers/auth.json
       with:
         containerfiles: deployment/docker/Dockerfile
         context: .


### PR DESCRIPTION
Somehow buildah doesn't know where podman stores its auth info